### PR TITLE
Updated Sensors and Config Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=connochio&repository=ambient_music&category=integration)

--- a/custom_components/ambient_music/__init__.py
+++ b/custom_components/ambient_music/__init__.py
@@ -6,9 +6,8 @@ from .const import DOMAIN
 
 PLATFORMS = [
     "number",
-    "input_text",
     "select",
-    "binary_sensor"
+    "binary_sensor",
 ]
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/ambient_music/__init__.py
+++ b/custom_components/ambient_music/__init__.py
@@ -8,6 +8,7 @@ PLATFORMS = [
     "number",
     "input_text",
     "select",
+    "binary_sensor"
 ]
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/ambient_music/binary_sensor.py
+++ b/custom_components/ambient_music/binary_sensor.py
@@ -1,0 +1,54 @@
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_state_change_event
+
+from .const import DOMAIN, CONF_PLAYLISTS
+
+class PlaylistSelectedSensor(BinarySensorEntity):
+    def __init__(self, playlist_name: str, input_select_entity: str):
+        self._playlist_name = playlist_name
+        self._input_select_entity = input_select_entity
+        self._attr_name = f"Playlist: {playlist_name} Selected"
+        self._attr_unique_id = f"{input_select_entity}_{playlist_name.replace(' ', '_').lower()}_selected"
+        self._attr_is_on = False
+
+    async def async_added_to_hass(self):
+        self._update_state()
+
+        @callback
+        def handle_state_change(event):
+            self._update_state()
+
+        async_track_state_change_event(
+            self.hass, [self._input_select_entity], handle_state_change
+        )
+
+    def _update_state(self):
+        current = self.hass.states.get(self._input_select_entity)
+        if current and current.state == self._playlist_name:
+            self._attr_is_on = True
+        else:
+            self._attr_is_on = False
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self):
+        return self._attr_is_on
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    data = entry.data
+    input_select_entity = data.get(CONF_PLAYLISTS)
+    playlist_state = hass.states.get(input_select_entity)
+
+    if not playlist_state or not hasattr(playlist_state, "attributes"):
+        return
+
+    playlist_options = playlist_state.attributes.get("options", [])
+    entities = [
+        PlaylistSelectedSensor(name, input_select_entity)
+        for name in playlist_options
+    ]
+    async_add_entities(entities)

--- a/custom_components/ambient_music/binary_sensor.py
+++ b/custom_components/ambient_music/binary_sensor.py
@@ -3,37 +3,44 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN, CONF_PLAYLISTS, DEVICE_INFO
 
-SELECT_ENTITY_ID = "select.ambient_music_playlist"
+SELECT_ENTITY_ID = "select.ambient_music_playlists"
 
-class PlaylistEnabledSensor(BinarySensorEntity):
+class PlaylistEnabledSensor(BinarySensorEntity, RestoreEntity):
     def __init__(self, hass: HomeAssistant, playlist_name: str):
         self.hass = hass
         self._playlist_name = playlist_name
-        self._attr_name = f"{playlist_name} Enabled"
-        self._attr_unique_id = f"ambient_music_{DOMAIN}_{playlist_name.lower().replace(' ', '_')}_enabled"
+        self._attr_name = f"Ambient Music {playlist_name} Enabled"
+        self._attr_unique_id = f"ambient_music_{playlist_name.lower().replace(' ', '_')}_enabled"
         self._attr_is_on = False
 
     async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+
+        if (last_state := await self.async_get_last_state()):
+            self._attr_is_on = last_state.state == "on"
+
+        async_track_state_change_event(self.hass, SELECT_ENTITY_ID, self._handle_select_change)
         self._update_state()
 
-        @callback
-        def handle_select_change(event):
-            self._update_state()
+    @callback
+    def _handle_select_change(self, event):
+        self._update_state()
 
-        async_track_state_change_event(self.hass, SELECT_ENTITY_ID, handle_select_change)
-
+    @callback
     def _update_state(self):
         state = self.hass.states.get(SELECT_ENTITY_ID)
-        self._attr_is_on = state and state.state == self._playlist_name
-        self.async_write_ha_state()
+        if state and state.state:
+            self._attr_is_on = state.state == self._playlist_name
+            self.async_write_ha_state()
 
     @property
     def is_on(self):
         return self._attr_is_on
-        
+
     @property
     def device_info(self):
         return DEVICE_INFO
@@ -46,4 +53,4 @@ async def async_setup_entry(
         playlists = playlists.splitlines()
 
     sensors = [PlaylistEnabledSensor(hass, name) for name in playlists]
-    async_add_entities(sensors)
+    async_add_entities(sensors, True)

--- a/custom_components/ambient_music/binary_sensor.py
+++ b/custom_components/ambient_music/binary_sensor.py
@@ -1,54 +1,49 @@
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, CONF_PLAYLISTS
+from .const import DOMAIN, CONF_PLAYLISTS, DEVICE_INFO
 
-class PlaylistSelectedSensor(BinarySensorEntity):
-    def __init__(self, playlist_name: str, input_select_entity: str):
+SELECT_ENTITY_ID = "select.ambient_music_playlist"
+
+class PlaylistEnabledSensor(BinarySensorEntity):
+    def __init__(self, hass: HomeAssistant, playlist_name: str):
+        self.hass = hass
         self._playlist_name = playlist_name
-        self._input_select_entity = input_select_entity
-        self._attr_name = f"Playlist: {playlist_name} Selected"
-        self._attr_unique_id = f"{input_select_entity}_{playlist_name.replace(' ', '_').lower()}_selected"
+        self._attr_name = f"{playlist_name} Enabled"
+        self._attr_unique_id = f"ambient_music_{DOMAIN}_{playlist_name.lower().replace(' ', '_')}_enabled"
         self._attr_is_on = False
 
     async def async_added_to_hass(self):
         self._update_state()
 
         @callback
-        def handle_state_change(event):
+        def handle_select_change(event):
             self._update_state()
 
-        async_track_state_change_event(
-            self.hass, [self._input_select_entity], handle_state_change
-        )
+        async_track_state_change_event(self.hass, SELECT_ENTITY_ID, handle_select_change)
 
     def _update_state(self):
-        current = self.hass.states.get(self._input_select_entity)
-        if current and current.state == self._playlist_name:
-            self._attr_is_on = True
-        else:
-            self._attr_is_on = False
+        state = self.hass.states.get(SELECT_ENTITY_ID)
+        self._attr_is_on = state and state.state == self._playlist_name
         self.async_write_ha_state()
 
     @property
     def is_on(self):
         return self._attr_is_on
+        
+    @property
+    def device_info(self):
+        return DEVICE_INFO
 
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+):
+    playlists = entry.data.get(CONF_PLAYLISTS, [])
+    if isinstance(playlists, str):
+        playlists = playlists.splitlines()
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
-    data = entry.data
-    input_select_entity = data.get(CONF_PLAYLISTS)
-    playlist_state = hass.states.get(input_select_entity)
-
-    if not playlist_state or not hasattr(playlist_state, "attributes"):
-        return
-
-    playlist_options = playlist_state.attributes.get("options", [])
-    entities = [
-        PlaylistSelectedSensor(name, input_select_entity)
-        for name in playlist_options
-    ]
-    async_add_entities(entities)
+    sensors = [PlaylistEnabledSensor(hass, name) for name in playlists]
+    async_add_entities(sensors)

--- a/custom_components/ambient_music/config_flow.py
+++ b/custom_components/ambient_music/config_flow.py
@@ -17,6 +17,10 @@ class AmbientMusicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         if user_input is not None:
+            playlist_string = user_input.get(CONF_PLAYLISTS, "")
+            playlist_list = [p.strip() for p in playlist_string.split(",") if p.strip()]
+            user_input[CONF_PLAYLISTS] = playlist_list
+
             return self.async_create_entry(title="Ambient Music", data=user_input)
 
         return self.async_show_form(

--- a/custom_components/ambient_music/config_flow.py
+++ b/custom_components/ambient_music/config_flow.py
@@ -17,10 +17,6 @@ class AmbientMusicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         if user_input is not None:
-            playlist_string = user_input.get(CONF_PLAYLISTS, "")
-            playlist_list = [p.strip() for p in playlist_string.split(",") if p.strip()]
-            user_input[CONF_PLAYLISTS] = playlist_list
-
             return self.async_create_entry(title="Ambient Music", data=user_input)
 
         return self.async_show_form(
@@ -30,7 +26,7 @@ class AmbientMusicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     EntitySelectorConfig(domain="media_player", multiple=True)
                 ),
                 vol.Required(CONF_PLAYLISTS): TextSelector(
-                    TextSelectorConfig(multiline=True)
+                    TextSelectorConfig(multiline=False, multiple=True)
                 ),
             })
         )

--- a/custom_components/ambient_music/const.py
+++ b/custom_components/ambient_music/const.py
@@ -6,6 +6,6 @@ CONF_PLAYLISTS = "playlists"
 DEVICE_INFO = {
     "identifiers": {(DOMAIN,)},
     "name": "Ambient Music",
-    "manufacturer": "Custom Integration",
-    "model": "v1"
+    "manufacturer": "Connochio",
+    "model": "Ambient Music Helpers"
 }

--- a/custom_components/ambient_music/const.py
+++ b/custom_components/ambient_music/const.py
@@ -6,6 +6,6 @@ CONF_PLAYLISTS = "playlists"
 DEVICE_INFO = {
     "identifiers": {(DOMAIN,)},
     "name": "Ambient Music",
-    "manufacturer": "Connochio",
-    "model": "Ambient Music Helpers"
+    "manufacturer": "Hillworks",
+    "model": "Ambient Music"
 }

--- a/custom_components/ambient_music/manifest.json
+++ b/custom_components/ambient_music/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ambient_music",
   "name": "Ambient Music",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "documentation": "https://github.com/connochio/ambient_music#readme",
   "requirements": [],
   "codeowners": ["@connochio"],

--- a/custom_components/ambient_music/number.py
+++ b/custom_components/ambient_music/number.py
@@ -2,7 +2,7 @@ from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN, DEVICE_INFO
 
@@ -14,7 +14,7 @@ NUMBER_ENTITIES = [
     ("Volume Fade Up Seconds", 0, 20, 1)
 ]
 
-class AmbientMusicNumber(NumberEntity):
+class AmbientMusicNumber(NumberEntity, RestoreEntity):
     def __init__(self, name, min_val, max_val, step):
         self._attr_name = f"Ambient Music {name}"
         self._attr_unique_id = self._attr_name.lower().replace(" ", "_")
@@ -23,10 +23,22 @@ class AmbientMusicNumber(NumberEntity):
         self._attr_native_step = step
         self._attr_native_value = min_val
         self._attr_mode = "auto"
-    
-    async def async_set_native_value(self, value: float) -> None:
+
+    async def async_added_to_hass(self):
+        await super().async_added_to_hass()
+        if (restored_state := await self.async_get_last_state()) is not None:
+            try:
+                self._attr_native_value = float(restored_state.state)
+            except ValueError:
+                pass
+
+    async def async_set_native_value(self, value: float):
         self._attr_native_value = value
         self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> float:
+        return self._attr_native_value
 
     @property
     def device_info(self):

--- a/custom_components/ambient_music/number.py
+++ b/custom_components/ambient_music/number.py
@@ -2,6 +2,7 @@ from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity import EntityCategory
 
 from .const import DOMAIN, DEVICE_INFO
 
@@ -13,12 +14,6 @@ NUMBER_ENTITIES = [
     ("Volume Fade Up Seconds", 0, 20, 1)
 ]
 
-async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
-):
-    entities = [AmbientMusicNumber(name, min_val, max_val, step) for name, min_val, max_val, step in NUMBER_ENTITIES]
-    async_add_entities(entities)
-
 class AmbientMusicNumber(NumberEntity):
     def __init__(self, name, min_val, max_val, step):
         self._attr_name = f"Ambient Music {name}"
@@ -28,7 +23,17 @@ class AmbientMusicNumber(NumberEntity):
         self._attr_native_step = step
         self._attr_native_value = min_val
         self._attr_mode = "auto"
+    
+    def set_native_value(self, value):
+        self._attr_native_value = value
+        self.async_write_ha_state()
 
     @property
     def device_info(self):
         return DEVICE_INFO
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+):
+    entities = [AmbientMusicNumber(name, min_val, max_val, step) for name, min_val, max_val, step in NUMBER_ENTITIES]
+    async_add_entities(entities)

--- a/custom_components/ambient_music/number.py
+++ b/custom_components/ambient_music/number.py
@@ -24,7 +24,7 @@ class AmbientMusicNumber(NumberEntity):
         self._attr_native_value = min_val
         self._attr_mode = "auto"
     
-    def set_native_value(self, value):
+    async def async_set_native_value(self, value: float) -> None:
         self._attr_native_value = value
         self.async_write_ha_state()
 

--- a/custom_components/ambient_music/select.py
+++ b/custom_components/ambient_music/select.py
@@ -8,7 +8,11 @@ from .const import DOMAIN, DEVICE_INFO, CONF_PLAYLISTS
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
-    playlists = entry.data.get(CONF_PLAYLISTS, "").splitlines()
+    # CONF_PLAYLISTS is now a list, not a multiline string
+    playlists = entry.data.get(CONF_PLAYLISTS, [])
+    if not isinstance(playlists, list):
+        playlists = [line.strip() for line in playlists.splitlines() if line.strip()]
+    
     entity = AmbientMusicPlaylistSelect(playlists)
     async_add_entities([entity])
 


### PR DESCRIPTION
Updated the following items:

- ✅ Updated config flow to allow multiple playlists to be added
- ✅ Updated sensors to keep states between restarts
- ✅ Created working binary sensor to show which playlist is currently enabled
- ✅ Updated readme to contain my hacs list
- ✅ Updated device details

Up next on the long list:

- Implement Spotify playlist items, tied to playlist names
- Implement Master On/Off switch
- Implement speaker selection volume calculation
- Implement time-based binary sensors to set the groundwork for automatic On/Off functionality
- Implement the ability to reconfigure the integration from the UI