### PR TITLE
1.1.5 dev.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Static Badge](https://img.shields.io/badge/HACS-Custom-41BDF5?style=for-the-badge&logo=homeassistantcommunitystore&logoColor=white)](https://github.com/hacs/integration)
+[![Static Badge](https://img.shields.io/badge/HACS-Custom-41BDF5?style=for-the-badge&logo=homeassistantcommunitystore&logoColor=white)](https://github.com/hacs/integration)  
 
-<img src="https://github.com/connochio/brands/blob/master/custom_integrations/ambient_music/icon.png" width=100>  
+<br /><img src="https://github.com/connochio/brands/blob/master/custom_integrations/ambient_music/icon.png" width=100>  
 
 # Ambient Music
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![Static Badge](https://img.shields.io/badge/HACS-Custom-41BDF5?style=for-the-badge&logo=homeassistantcommunitystore&logoColor=white)](https://github.com/hacs/integration)  
 
-<br /><img src="https://github.com/connochio/brands/blob/master/custom_integrations/ambient_music/icon.png" width=100>  
-
 # Ambient Music
 
 A Home Assistant integration for playing ambient music on supported players via Music Assistant.
@@ -22,16 +20,19 @@ Install this integration via HACS with the link above.
 
 ## Description
 
-This integration will create user-configurable helpers to set various aspects of the ambient music system, including:  
+This integration allows for users to create playlist selections that will play automatically on supported players via music assistant.  
 
-- The amount of time to fade music in.
-- The amount of time to fade music out.
-- The default volume for player entities.
+When turned on or off, music will fade in and out for a configurable amount of seconds, to a user-selected default volume.  
 
-In addition, it will also create static non-configurable helpers to start or stop automations, such as:  
+Playlists will also fade out and back in from each-other seamlessly when changed.
 
-- A master on/off switch for all ambient music.
-- Binary sensors for each playlist, enabled when a playlist is selected.
+User configurable options include:
+- Default volume
+- Music fade in time
+- Music fade out time
+- Time to wait between swapping playlists
+- Playlist names and spotify IDs
+
 
 <details>
   <summary>Planned future helpers, switches and/or user-configurable settings</summary>
@@ -52,4 +53,3 @@ In addition, it will also create static non-configurable helpers to start or sto
 
 ## Credits and Thanks
 
-Icon design and creation by Lauren Peploe: [Website](https://laurenpeploe.co.uk/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Static Badge](https://img.shields.io/badge/HACS-Custom-41BDF5?style=for-the-badge&logo=homeassistantcommunitystore&logoColor=white)](https://github.com/hacs/integration) 
+[![Static Badge](https://img.shields.io/badge/HACS-Custom-41BDF5?style=for-the-badge&logo=homeassistantcommunitystore&logoColor=white)](https://github.com/hacs/integration)
+
+<img src="https://github.com/connochio/brands/blob/master/custom_integrations/ambient_music/icon.png" width=100>  
 
 # Ambient Music
 
@@ -14,7 +16,7 @@ A Home Assistant integration for playing ambient music on supported players via 
 
 ## Installation
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=connochio&repository=ambient_music&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=connochio&repository=ambient_music&category=Integration)
 
 Install this integration via HACS with the link above.
 
@@ -47,3 +49,7 @@ In addition, it will also create static non-configurable helpers to start or sto
 ## Setup
 
 <i>Coming Soon</i>
+
+## Credits and Thanks
+
+Icon design and creation by Lauren Peploe: [Website](https://laurenpeploe.co.uk/)

--- a/custom_components/ambient_music/__init__.py
+++ b/custom_components/ambient_music/__init__.py
@@ -17,6 +17,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
 
+    # Reload entities whenever options change via the cog
+    async def _options_updated(hass: HomeAssistant, updated_entry: ConfigEntry):
+        await hass.config_entries.async_reload(updated_entry.entry_id)
+
+    entry.async_on_unload(entry.add_update_listener(_options_updated))
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/custom_components/ambient_music/config_flow.py
+++ b/custom_components/ambient_music/config_flow.py
@@ -15,12 +15,9 @@ from .const import (
 
 def _clean_playlists(playlists):
     if isinstance(playlists, str):
-        # Could happen in older entries, split on newlines
         playlists = [line.strip() for line in playlists.splitlines()]
     elif not isinstance(playlists, list):
         playlists = []
-
-    # Strip whitespace, remove blanks
     return [p.strip() for p in playlists if p and p.strip()]
 
 

--- a/custom_components/ambient_music/config_flow.py
+++ b/custom_components/ambient_music/config_flow.py
@@ -1,10 +1,13 @@
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import (
     EntitySelector,
     EntitySelectorConfig,
     TextSelector,
     TextSelectorConfig,
+    SelectSelector,
+    SelectSelectorConfig,
 )
 
 from .const import (
@@ -13,12 +16,29 @@ from .const import (
     CONF_PLAYLISTS,
 )
 
+
 def _clean_playlists(playlists):
     if isinstance(playlists, str):
         playlists = [line.strip() for line in playlists.splitlines()]
     elif not isinstance(playlists, list):
         playlists = []
-    return [p.strip() for p in playlists if p and p.strip()]
+
+    cleaned = [p.strip() for p in playlists if p and p.strip()]
+    seen = set()
+    result = []
+    for p in cleaned:
+        if p not in seen:
+            seen.add(p)
+            result.append(p)
+    return result
+
+
+def _get_current(hass: HomeAssistant, entry: config_entries.ConfigEntry):
+    opts = entry.options or {}
+    data = entry.data or {}
+    players = opts.get(CONF_MEDIA_PLAYERS, data.get(CONF_MEDIA_PLAYERS, []))
+    playlists = opts.get(CONF_PLAYLISTS, data.get(CONF_PLAYLISTS, []))
+    return players, _clean_playlists(playlists)
 
 
 class AmbientMusicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -70,4 +90,107 @@ class AmbientMusicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
             }),
             errors=errors,
+        )
+
+    @staticmethod
+    def async_get_options_flow(config_entry):
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        return self.async_show_menu(
+            step_id="init",
+            menu_options={
+                "core": "Core settings",
+                "add_playlists": "Add playlists",
+                "remove_playlists": "Remove playlists",
+            },
+        )
+
+    async def async_step_core(self, user_input=None):
+        current_players, current_playlists = _get_current(self.hass, self.config_entry)
+
+        if user_input is not None:
+            options = {
+                CONF_MEDIA_PLAYERS: user_input[CONF_MEDIA_PLAYERS],
+                CONF_PLAYLISTS: _clean_playlists(user_input[CONF_PLAYLISTS]),
+            }
+            return self.async_create_entry(title="", data=options)
+
+        return self.async_show_form(
+            step_id="core",
+            data_schema=vol.Schema({
+                vol.Required(
+                    CONF_MEDIA_PLAYERS,
+                    default=current_players
+                ): EntitySelector(
+                    EntitySelectorConfig(domain="media_player", multiple=True)
+                ),
+                vol.Required(
+                    CONF_PLAYLISTS,
+                    default=current_playlists
+                ): TextSelector(
+                    TextSelectorConfig(multiline=False, multiple=True)
+                ),
+            }),
+        )
+
+    async def async_step_add_playlists(self, user_input=None):
+        _, current_playlists = _get_current(self.hass, self.config_entry)
+
+        if user_input is not None:
+            to_add = _clean_playlists(user_input[CONF_PLAYLISTS])
+            merged = _clean_playlists(current_playlists + to_add)
+            options = {
+                CONF_MEDIA_PLAYERS: _get_current(self.hass, self.config_entry)[0],
+                CONF_PLAYLISTS: merged,
+            }
+            return self.async_create_entry(title="", data=options)
+
+        return self.async_show_form(
+            step_id="add_playlists",
+            data_schema=vol.Schema({
+                vol.Required(CONF_PLAYLISTS): TextSelector(
+                    TextSelectorConfig(
+                        multiline=False,
+                        multiple=True,
+                    )
+                ),
+            }),
+            description_placeholders={
+                "count": str(len(current_playlists)),
+            },
+        )
+
+    async def async_step_remove_playlists(self, user_input=None):
+        _, current_playlists = _get_current(self.hass, self.config_entry)
+
+        if user_input is not None:
+            to_remove = set(user_input.get(CONF_PLAYLISTS, []))
+            new_list = [p for p in current_playlists if p not in to_remove]
+            options = {
+                CONF_MEDIA_PLAYERS: _get_current(self.hass, self.config_entry)[0],
+                CONF_PLAYLISTS: new_list,
+            }
+            return self.async_create_entry(title="", data=options)
+
+        return self.async_show_form(
+            step_id="remove_playlists",
+            data_schema=vol.Schema({
+                vol.Required(
+                    CONF_PLAYLISTS,
+                    default=[]
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=current_playlists,
+                        multiple=True,
+                        custom_value=False,
+                    )
+                ),
+            }),
         )

--- a/custom_components/ambient_music/config_flow.py
+++ b/custom_components/ambient_music/config_flow.py
@@ -1,3 +1,4 @@
+import re
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
@@ -14,39 +15,56 @@ from .const import (
     DOMAIN,
     CONF_MEDIA_PLAYERS,
     CONF_PLAYLISTS,
+    CONF_SPOTIFY_ID,
 )
 
-
-def _clean_playlists(playlists):
+def _clean_name_list(playlists):
     if isinstance(playlists, str):
         playlists = [line.strip() for line in playlists.splitlines()]
     elif not isinstance(playlists, list):
         playlists = []
-
-    cleaned = [p.strip() for p in playlists if p and p.strip()]
-    seen = set()
-    result = []
-    for p in cleaned:
-        if p not in seen:
-            seen.add(p)
-            result.append(p)
-    return result
+    return [p.strip() for p in playlists if p and p.strip()]
 
 
-def _get_current(hass: HomeAssistant, entry: config_entries.ConfigEntry):
+def _normalize_mapping(raw):
+    if isinstance(raw, dict):
+        out = {}
+        for k, v in raw.items():
+            name = str(k).strip()
+            sid = str(v).strip() if v is not None else ""
+            if name:
+                out[name] = sid
+        return out
+    names = _clean_name_list(raw)
+    return {n: "" for n in names}
+
+
+_SPOTIFY_ID_RE = re.compile(r"^[A-Za-z0-9]{22}$")
+
+def _extract_spotify_id(text: str) -> str:
+    if not text:
+        return ""
+    text = text.strip()
+    if _SPOTIFY_ID_RE.fullmatch(text):
+        return text
+
+    m = re.search(r"(?:playlist/|playlist:)([A-Za-z0-9]{22})", text)
+    return m.group(1) if m else ""
+
+
+def _get_players_and_map(hass: HomeAssistant, entry: config_entries.ConfigEntry):
     opts = entry.options or {}
     data = entry.data or {}
     players = opts.get(CONF_MEDIA_PLAYERS, data.get(CONF_MEDIA_PLAYERS, []))
-    playlists = opts.get(CONF_PLAYLISTS, data.get(CONF_PLAYLISTS, []))
-    return players, _clean_playlists(playlists)
-
+    playlist_map = _normalize_mapping(opts.get(CONF_PLAYLISTS, data.get(CONF_PLAYLISTS, {})))
+    return players, playlist_map
 
 class AmbientMusicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     async def async_step_user(self, user_input=None):
         if user_input is not None:
-            user_input[CONF_PLAYLISTS] = _clean_playlists(user_input[CONF_PLAYLISTS])
+            user_input[CONF_PLAYLISTS] = _clean_name_list(user_input[CONF_PLAYLISTS])
             return self.async_create_entry(title="Ambient Music", data=user_input)
 
         return self.async_show_form(
@@ -67,7 +85,7 @@ class AmbientMusicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         current_data = current_entry.data
 
         if user_input is not None:
-            user_input[CONF_PLAYLISTS] = _clean_playlists(user_input[CONF_PLAYLISTS])
+            user_input[CONF_PLAYLISTS] = _clean_name_list(user_input[CONF_PLAYLISTS])
             return self.async_update_reload_and_abort(
                 current_entry,
                 data_updates=user_input,
@@ -96,34 +114,34 @@ class AmbientMusicConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def async_get_options_flow(config_entry):
         return OptionsFlowHandler(config_entry)
 
-
 class OptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         self.config_entry = config_entry
+        self._pending_add = None
 
     async def async_step_init(self, user_input=None):
         return self.async_show_menu(
             step_id="init",
             menu_options={
-                "core": "Core settings",
-                "add_playlists": "Add playlists",
+                "media_players": "Core settings (media players)",
+                "add_playlist": "Add playlist",
                 "remove_playlists": "Remove playlists",
             },
         )
 
-    async def async_step_core(self, user_input=None):
-        current_players, current_playlists = _get_current(self.hass, self.config_entry)
+    async def async_step_media_players(self, user_input=None):
+        current_players, playlist_map = _get_players_and_map(self.hass, self.config_entry)
 
         if user_input is not None:
             options = {
                 CONF_MEDIA_PLAYERS: user_input[CONF_MEDIA_PLAYERS],
-                CONF_PLAYLISTS: _clean_playlists(user_input[CONF_PLAYLISTS]),
+                CONF_PLAYLISTS: playlist_map,  # preserve mapping
             }
             return self.async_create_entry(title="", data=options)
 
         return self.async_show_form(
-            step_id="core",
+            step_id="media_players",
             data_schema=vol.Schema({
                 vol.Required(
                     CONF_MEDIA_PLAYERS,
@@ -131,66 +149,80 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): EntitySelector(
                     EntitySelectorConfig(domain="media_player", multiple=True)
                 ),
-                vol.Required(
-                    CONF_PLAYLISTS,
-                    default=current_playlists
-                ): TextSelector(
-                    TextSelectorConfig(multiline=False, multiple=True)
-                ),
             }),
         )
 
-    async def async_step_add_playlists(self, user_input=None):
-        _, current_playlists = _get_current(self.hass, self.config_entry)
+    async def async_step_add_playlist(self, user_input=None):
+        _, playlist_map = _get_players_and_map(self.hass, self.config_entry)
 
         if user_input is not None:
-            to_add = _clean_playlists(user_input[CONF_PLAYLISTS])
-            merged = _clean_playlists(current_playlists + to_add)
+            name = str(user_input["name"]).strip()
+            raw = str(user_input[CONF_SPOTIFY_ID]).strip()
+            sid = _extract_spotify_id(raw)
+
+            errors = {}
+            if not name:
+                errors["name"] = "required"
+            elif name in playlist_map:
+                errors["name"] = "already_configured"
+
+            if not sid:
+                errors[CONF_SPOTIFY_ID] = "invalid_spotify_id"
+
+            if errors:
+                return self.async_show_form(
+                    step_id="add_playlist",
+                    data_schema=_add_schema(default_name=name, default_sid=raw),
+                    errors=errors,
+                )
+
+            playlist_map[name] = sid
             options = {
-                CONF_MEDIA_PLAYERS: _get_current(self.hass, self.config_entry)[0],
-                CONF_PLAYLISTS: merged,
+                CONF_MEDIA_PLAYERS: _get_players_and_map(self.hass, self.config_entry)[0],
+                CONF_PLAYLISTS: playlist_map,
             }
             return self.async_create_entry(title="", data=options)
 
-        return self.async_show_form(
-            step_id="add_playlists",
-            data_schema=vol.Schema({
-                vol.Required(CONF_PLAYLISTS): TextSelector(
-                    TextSelectorConfig(
-                        multiline=False,
-                        multiple=True,
-                    )
-                ),
-            }),
-            description_placeholders={
-                "count": str(len(current_playlists)),
-            },
-        )
+        return self.async_show_form(step_id="add_playlist", data_schema=_add_schema())
 
     async def async_step_remove_playlists(self, user_input=None):
-        _, current_playlists = _get_current(self.hass, self.config_entry)
+        _, playlist_map = _get_players_and_map(self.hass, self.config_entry)
+        names = list(playlist_map.keys())
 
         if user_input is not None:
             to_remove = set(user_input.get(CONF_PLAYLISTS, []))
-            new_list = [p for p in current_playlists if p not in to_remove]
+            for n in list(playlist_map.keys()):
+                if n in to_remove:
+                    playlist_map.pop(n, None)
+
             options = {
-                CONF_MEDIA_PLAYERS: _get_current(self.hass, self.config_entry)[0],
-                CONF_PLAYLISTS: new_list,
+                CONF_MEDIA_PLAYERS: _get_players_and_map(self.hass, self.config_entry)[0],
+                CONF_PLAYLISTS: playlist_map,
             }
             return self.async_create_entry(title="", data=options)
 
         return self.async_show_form(
             step_id="remove_playlists",
             data_schema=vol.Schema({
-                vol.Required(
-                    CONF_PLAYLISTS,
-                    default=[]
-                ): SelectSelector(
+                vol.Required(CONF_PLAYLISTS, default=[]): SelectSelector(
                     SelectSelectorConfig(
-                        options=current_playlists,
+                        options=names,
                         multiple=True,
                         custom_value=False,
                     )
                 ),
             }),
         )
+
+
+def _add_schema(default_name: str = "", default_sid: str = "") -> vol.Schema:
+    return vol.Schema({
+        vol.Required("name", default=default_name): TextSelector(
+            TextSelectorConfig(multiline=False)
+        ),
+        vol.Required(CONF_SPOTIFY_ID, default=default_sid): TextSelector(
+            TextSelectorConfig(
+                multiline=False,
+            )
+        ),
+    })

--- a/custom_components/ambient_music/const.py
+++ b/custom_components/ambient_music/const.py
@@ -2,6 +2,7 @@ DOMAIN = "ambient_music"
 
 CONF_MEDIA_PLAYERS = "media_players"
 CONF_PLAYLISTS = "playlists"
+CONF_SPOTIFY_ID = "spotify_id"
 
 DEVICE_INFO = {
     "identifiers": {(DOMAIN,)},

--- a/custom_components/ambient_music/manifest.json
+++ b/custom_components/ambient_music/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ambient_music",
   "name": "Ambient Music",
-  "version": "v1.1.5-dev.1",
+  "version": "v1.1.5-dev.2",
   "codeowners": ["@connochio"],
   "dependencies": [],
   "documentation": "https://github.com/connochio/ambient_music#readme",

--- a/custom_components/ambient_music/manifest.json
+++ b/custom_components/ambient_music/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ambient_music",
   "name": "Ambient Music",
-  "version": "v1.1.3-alpha",
+  "version": "v1.1.5-dev.1",
   "codeowners": ["@connochio"],
   "dependencies": [],
   "documentation": "https://github.com/connochio/ambient_music#readme",

--- a/custom_components/ambient_music/manifest.json
+++ b/custom_components/ambient_music/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ambient_music",
   "name": "Ambient Music",
-  "version": "v1.1.5-dev.2",
+  "version": "v1.1.5-a.0",
   "codeowners": ["@connochio"],
   "dependencies": [],
   "documentation": "https://github.com/connochio/ambient_music#readme",

--- a/custom_components/ambient_music/select.py
+++ b/custom_components/ambient_music/select.py
@@ -3,16 +3,20 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, DEVICE_INFO, CONF_PLAYLISTS
+from .const import DEVICE_INFO, CONF_PLAYLISTS
+
+def _get_playlists(entry: ConfigEntry):
+    playlists = entry.options.get(CONF_PLAYLISTS, entry.data.get(CONF_PLAYLISTS, []))
+    if isinstance(playlists, str):
+        playlists = [line.strip() for line in playlists.splitlines() if line.strip()]
+    elif not isinstance(playlists, list):
+        playlists = []
+    return playlists
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
-    # CONF_PLAYLISTS is now a list, not a multiline string
-    playlists = entry.data.get(CONF_PLAYLISTS, [])
-    if not isinstance(playlists, list):
-        playlists = [line.strip() for line in playlists.splitlines() if line.strip()]
-    
+    playlists = _get_playlists(entry)
     entity = AmbientMusicPlaylistSelect(playlists)
     async_add_entities([entity])
 

--- a/custom_components/ambient_music/select.py
+++ b/custom_components/ambient_music/select.py
@@ -5,27 +5,34 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DEVICE_INFO, CONF_PLAYLISTS
 
-def _get_playlists(entry: ConfigEntry):
-    playlists = entry.options.get(CONF_PLAYLISTS, entry.data.get(CONF_PLAYLISTS, []))
-    if isinstance(playlists, str):
-        playlists = [line.strip() for line in playlists.splitlines() if line.strip()]
-    elif not isinstance(playlists, list):
-        playlists = []
-    return playlists
+
+def _get_playlist_mapping(entry: ConfigEntry):
+    raw = entry.options.get(CONF_PLAYLISTS, entry.data.get(CONF_PLAYLISTS, {}))
+    if isinstance(raw, dict):
+        return {str(k): str(v) for k, v in raw.items()}
+    if isinstance(raw, list):
+        return {s: "" for s in (x.strip() for x in raw) if s}
+    if isinstance(raw, str):
+        return {s: "" for s in (x.strip() for x in raw.splitlines()) if s}
+    return {}
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
-    playlists = _get_playlists(entry)
-    entity = AmbientMusicPlaylistSelect(playlists)
+    mapping = _get_playlist_mapping(entry)
+    playlists = list(mapping.keys())
+    entity = AmbientMusicPlaylistSelect(playlists, mapping)
     async_add_entities([entity])
 
+
 class AmbientMusicPlaylistSelect(SelectEntity):
-    def __init__(self, options):
+    def __init__(self, options, mapping):
         self._attr_name = "Ambient Music Playlists"
         self._attr_unique_id = "ambient_music_playlists"
         self._attr_options = options
         self._attr_current_option = options[0] if options else None
+        self._mapping = mapping  # {name: spotify_id}
 
     @property
     def device_info(self):
@@ -35,3 +42,12 @@ class AmbientMusicPlaylistSelect(SelectEntity):
         if option in self._attr_options:
             self._attr_current_option = option
             self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self):
+        attrs = {"playlists": self._mapping}
+        if self._attr_current_option:
+            attrs["current_spotify_id"] = self._mapping.get(
+                self._attr_current_option, ""
+            )
+        return attrs


### PR DESCRIPTION
- ✅ Implemented proper config flow instead of reconfigure
- ✅ Implemented separate config flows for playlists and media players
- ✅ Implemented spotify IDs
- ✅ Implemented attributes for the playlist selector for spotify IDs
- ✅ Linked spotify IDs to playlists names
  
Left to do before v1.2.0:  
- Remove legacy reconfigure options
- Update config flow item names
- General code and UI cleanup
- Add TOD binary sensors
- Add master on/off switch