### PR TITLE
1.1.6 dev.1

### DIFF
--- a/custom_components/ambient_music/__init__.py
+++ b/custom_components/ambient_music/__init__.py
@@ -5,8 +5,8 @@ from homeassistant.helpers.typing import ConfigType
 from .const import DOMAIN
 
 PLATFORMS = [
-    "number",
-    "select",
+    "number", 
+    "select", 
     "binary_sensor"
 ]
 
@@ -14,10 +14,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data
-
-    # Reload entities whenever options change via the cog
     async def _options_updated(hass: HomeAssistant, updated_entry: ConfigEntry):
         await hass.config_entries.async_reload(updated_entry.entry_id)
 
@@ -27,7 +23,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unloaded:
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unloaded
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/ambient_music/manifest.json
+++ b/custom_components/ambient_music/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ambient_music",
   "name": "Ambient Music",
-  "version": "v1.1.5-a.0",
+  "version": "v1.1.6-dev.1",
   "codeowners": ["@connochio"],
   "dependencies": [],
   "documentation": "https://github.com/connochio/ambient_music#readme",

--- a/custom_components/ambient_music/manifest.json
+++ b/custom_components/ambient_music/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ambient_music",
   "name": "Ambient Music",
-  "version": "v1.1.6-dev.1",
+  "version": "v1.1.6-a.0",
   "codeowners": ["@connochio"],
   "dependencies": [],
   "documentation": "https://github.com/connochio/ambient_music#readme",

--- a/custom_components/ambient_music/select.py
+++ b/custom_components/ambient_music/select.py
@@ -5,34 +5,33 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DEVICE_INFO, CONF_PLAYLISTS
 
+def _get_playlist_mapping(entry: ConfigEntry) -> dict[str, str]:
+    """Strictly from options: {name: spotify_id}."""
+    raw = entry.options.get(CONF_PLAYLISTS, {})
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items()}
 
-def _get_playlist_mapping(entry: ConfigEntry):
-    raw = entry.options.get(CONF_PLAYLISTS, entry.data.get(CONF_PLAYLISTS, {}))
-    if isinstance(raw, dict):
-        return {str(k): str(v) for k, v in raw.items()}
-    if isinstance(raw, list):
-        return {s: "" for s in (x.strip() for x in raw) if s}
-    if isinstance(raw, str):
-        return {s: "" for s in (x.strip() for x in raw.splitlines()) if s}
-    return {}
-
+def _to_uri_map(mapping: dict[str, str]) -> dict[str, str]:
+    return {name: (f"spotify:playlist:{sid}" if sid else "") for name, sid in mapping.items()}
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
-    mapping = _get_playlist_mapping(entry)
+    mapping = _get_playlist_mapping(entry)          # {name: id}
     playlists = list(mapping.keys())
     entity = AmbientMusicPlaylistSelect(playlists, mapping)
     async_add_entities([entity])
 
-
 class AmbientMusicPlaylistSelect(SelectEntity):
-    def __init__(self, options, mapping):
-        self._attr_name = "Ambient Music Playlists"
-        self._attr_unique_id = "ambient_music_playlists"
+    _attr_name = "Ambient Music Playlists"
+    _attr_unique_id = "ambient_music_playlists"
+
+    def __init__(self, options: list[str], mapping: dict[str, str]):
         self._attr_options = options
         self._attr_current_option = options[0] if options else None
-        self._mapping = mapping  # {name: spotify_id}
+        self._mapping = mapping                  # {name: id}
+        self._uri_map = _to_uri_map(mapping)     # {name: uri}
 
     @property
     def device_info(self):
@@ -45,9 +44,15 @@ class AmbientMusicPlaylistSelect(SelectEntity):
 
     @property
     def extra_state_attributes(self):
-        attrs = {"playlists": self._mapping}
+        attrs = {
+            "playlists": self._mapping,      # {name: spotify_id}
+            "playlist_uris": self._uri_map,  # {name: spotify:playlist:<id>}
+        }
+        current_id = ""
+        current_uri = ""
         if self._attr_current_option:
-            attrs["current_spotify_id"] = self._mapping.get(
-                self._attr_current_option, ""
-            )
+            current_id = self._mapping.get(self._attr_current_option, "")
+            current_uri = self._uri_map.get(self._attr_current_option, "")
+        attrs["current_spotify_id"] = current_id
+        attrs["current_spotify_uri"] = current_uri
         return attrs


### PR DESCRIPTION
- ✅ Removed legacy reconfigure and keys
- ✅ Updated config flow item names
- ✅ Removed initial configuration steps
- ✅ Removed ability to change playlist names to avoid binary sensor issues
- ✅ Implemented better duplicate playlist name handling

Left to do before v1.2.0:

- Add TOD binary sensors
- Add master on/off switch
- Add blocker entities and binary sensor